### PR TITLE
Restructure API repository and add servers.md

### DIFF
--- a/api-repository.md
+++ b/api-repository.md
@@ -3,21 +3,21 @@
 There are a lot of tools, libraries and frameworks for Bukkit-based plugin development.
 This file lists an unexhaustive selection.
 
-- Frameworks
-- Utilities
-  - Version Independent Code
-  - Dependency Management
-  - Bridges
-  - Packets
-- Other Languages
-- Commands
-- Libraries
-  - NPCs
-  - Maps
-  - GUIs
-  - Scoreboards
-  - Holograms
-  - Worlds
+- [Frameworks](#Frameworks)
+- [Utilities](#Utilities)
+  - [Version Independent Code](#Version-Independent-Code)
+  - [Dependency Management](#Dependency-Management)
+  - [Bridges](#Bridges)
+  - [Packets](#Packets)
+- [Other Languages](#Other-Languages)
+- [Commands](#Commands)
+- [Libraries](#Libraries)
+  - [NPCs](#NPCs)
+  - [Maps](#Maps)
+  - [GUIs](#GUIs)
+  - [Scoreboards](#Scoreboards)
+  - [Holograms](#Holograms)
+  - [Worlds](#Worlds)
 
 ## Frameworks
 
@@ -191,7 +191,7 @@ Libraries are projects that focus on a specific aspect of plugins.
 
   More features and examples can be found [here](https://minuskube.gitbook.io/smartinvs/).
 
-## Scoreboards
+### Scoreboards
 
 - [Netherboard](https://github.com/MinusKube/Netherboard) by [@MinusKube](https://github.com/MinusKube/)
 
@@ -205,13 +205,13 @@ Libraries are projects that focus on a specific aspect of plugins.
 
   > This API adds custom lines of text below a players name.
   
-## Holograms
+### Holograms
 
 - [HolographicDisplays](https://github.com/filoghost/HolographicDisplays) by [@filoghost](https://github.com/filoghost)
 
   > Plugin and API to create holograms.
   
-## Worlds
+### Worlds
 
 - [WorldGeneratorAPI](https://github.com/rutgerkok/WorldGeneratorApi) by [@rutgerkok](https://github.com/rutgerkok)
 

--- a/api-repository.md
+++ b/api-repository.md
@@ -17,6 +17,7 @@ This file lists an unexhaustive selection.
   - [GUIs](#GUIs)
   - [Scoreboards](#Scoreboards)
   - [Holograms](#Holograms)
+  - [NBT](#NBT)
   - [Worlds](#Worlds)
 
 ## Frameworks

--- a/api-repository.md
+++ b/api-repository.md
@@ -1,68 +1,32 @@
-API repository
----
-Nowadays, there exists a lot of useful Spigot APIs that reduce boilerplate.
-This file lists some of them.
+# API repository
 
-## Commands
-- [commands](https://github.com/aikar/commands) by [@aikar](https://github.com/aikar/)
+There are a lot of tools, libraries and frameworks for Bukkit-based plugin development.
+This file lists an unexhaustive selection.
 
-  > commands is a command dispatcher framework that reduces boilerplate by annotations.
+- Frameworks
+- Utilities
+  - Version Independent Code
+  - Dependency Management
+  - Bridges
+  - Packets
+- Other Languages
+- Commands
+- Libraries
+  - NPCs
+  - Maps
+  - GUIs
+  - Scoreboards
+  - Holograms
+  - Worlds
 
-- [kaesk](https://github.com/DRSchlaubi/kaesk) by [@DRSchlaubi](https://github.com/DRSchlaubi)
+## Frameworks
 
-  > kaesk is an annotation-based command framework that reduces duplicated code and boilerplate.
-  
-  __Main features__:
-  - annotation-based command handling
-  - every command is a dedicated method
-  - custom error and argument handler
-  - simple and easy-to-use
+Full-blown frameworks that operate on top of Bukkit and define how you write your plugins.
 
-## NPCs
-- [NPCLib](https://github.com/MinecraftLibraries/NPCLib) by [@JitseB](https://github.com/JitseB)
-  
-  > Library that allows developers to create NPCs with an easy-to-use API.
-
-## Inventories
-- [AnvilGUI](https://github.com/WesJD/AnvilGUI) by [@WesJD](https://github.com/WesJD/)
-
-  > AnvilGUI provides an API to open an anvil inventory that reacts on renaming.
-  
-    __Main features__:
-    - support of nearly every version
-    - easy-to-use builder
-    - set title, items, closing listener and completion listener
-
-- [SmartInvs](https://github.com/MinusKube/SmartInvs) by [@MinusKube](https://github.com/MinusKube/)
-  
-  > SmartInvs provides an interface for creating inventories by setting clickable items.
-  
-  __Main features__:
-  - Iterator for inventory slots
-  - Page system
-  - Util methods to fill an inventory's row/column/borders/...
-  - Actions when player clicks on an item
-    
-  More features and examples can be found [here](https://minuskube.gitbook.io/smartinvs/).
-  
-## Scoreboards
-- [Netherboard](https://github.com/MinusKube/Netherboard) by [@MinusKube](https://github.com/MinusKube/)
-
-  > Netherboard provides a simple-to-use wrapper for scoreboards.
-  
-  __Main features__:
-  - simple syntax for creation `BPlayerBoard board = Netherboard.instance().createBoard(player, scoreboard, "My Scoreboard");`
-  - simple syntax for adding/removing scores: `board.set("Test Score", 5);`, `board.remove(5)`
-  
-- [MultiLineAPI](https://github.com/iso2013/MultiLineAPI) by [@iso2013](https://github.com/iso2013/)
-
-  > This API adds custom lines of text below a players name.
-
-## Create version-independent plugins
 - [kelp](https://github.com/PXAV/kelp) by [@PXAV](https://github.com/PXAV/)
 
   > kelp is an all-in-one framework that aims to avoid version-depended code.
-  
+
   __Main features__:
   - Sidebar system
   - Inventory system
@@ -70,53 +34,201 @@ This file lists some of them.
   - Command system
   - Config system
 
-- [XSeries](https://github.com/CryptoMorin/XSeries) by [@CryptoMorin](https://github.com/CryptoMorin)
+## Utilities
 
-  > XSeries provides abstraction for several version-depended classes.
-  
-  __Main features__:
-  - potions, materials, sounds, particles, ...
-  - blocks, entities, bioms
+Tools that help you with compatibility, interopability and workflow.
 
-## Other resources
+### Environment
+
+- [MinecraftDev](https://github.com/minecraft-dev/MinecraftDev) by [@minecraft-dev](https://github.com/minecraft-dev)
+
+  > An IntelliJ plugin that helps you with plugin projects, among others.
+
 - [docker-minecraft-server](https://github.com/itzg/docker-minecraft-server) by [@itzg](https://github.com/itzg)
 
   > Dockerize minecraft servers by providing customizable images.
-  
-- [WLOSP](https://github.com/WeLoveOpenSourcePlugins/contribute) (organization)
 
-  > An organization that clones premium plugins (plugins you have to pay for) and publishes them on GitHub - free-to-use and open-source.
-  
-- [Cleanstone](https://github.com/CleanstoneMC/Cleanstone) by [@Fionera](https://github.com/Fionera) and [@MyzelYam](https://github.com/MyzelYam)
+### Version Independent Code
 
-  > Cleanstone is an alternative server software that is based on Spring and Multi-Threading.
-  
-- [Geyser](https://github.com/GeyserMC/Geyser) by [@GeyserMC](https://github.com/GeyserMC/)
+- [XSeries](https://github.com/CryptoMorin/XSeries) by [@CryptoMorin](https://github.com/CryptoMorin)
 
-  > Geyser is a proxy that allows "Bedrock players" to join "Java servers". Note that the project is not production-ready.
-  
-- [Minestom](https://github.com/Minestom/Minestom) by [@Minestom](https://github.com/Minestom/)
+  > XSeries provides abstraction for several version-depended classes.
 
-  > Minestom is an alternative server software that aims to improve the performance.
-  
-   __Main features__:
-   - Remove the overhead of vanilla features
-   - Multi-threaded (Chunks & Entities)
-   - Instance system which is much more scalable than worlds
-   - Modern API
-   
-- [PaperMC](https://github.com/PaperMC/Paper)
+  __Main features__:
+  - potions, materials, sounds, particles, ...
+  - blocks, entities, bioms
+- [compatre](https://github.com/johnnyjayjay/compatre) by [@JohnnyJayJay](https://github.com/johnnyjayjay)
 
-  > The known PaperMC server software.
-  
-- [MinecraftDev](https://github.com/minecraft-dev/MinecraftDev) by [@minecraft-dev](https://github.com/minecraft-dev)
+  > compatre replaces version-specific nms and craftbukkit types at runtime using bytecode manipulation.
 
-  > An IntelliJ plugin that setups minecraft plugin projects.
+  __Main features:__
+  - Version compatibility with only a single annotation
+  - Java agent/Custom class loader
+
+### Dependency Management
+
+- [pdm](https://github.com/knightzmc/pdm) by [@knightzmc](https://github.com/knightzmc)
+
+  > pdm lets you add your external dependencies to the classpath without shading.
+  
+  __Main features:__
+  - Declarative dependency notation
+  - Reuse of shared dependencies (including transitive ones)
+  - Plugin to integrate with Gradle
+- [libby](https://github.com/Byteflux/libby) by [@Byteflux](https://github.com/Byteflux)
+
+  > libby lets you add your external dependencies to the classpath without shading.
+  
+  __Main features:__
+  - Dependency relocation
+  
+### Bridges
+
+- [PlaceholderAPI](https://github.com/PlaceholderAPI/PlaceholderAPI) by [@extendedclip](https://github.com/extendedclip)
+
+  > PlaceholderAPI provides a uniform way to share information with and use information from other plugins.
+  
+  __Main features:__
+  - Developer API 
+  - External expansions
+- [Vault](https://github.com/milkbowl/Vault) by [@MilkBowl](https://github.com/milkbowl)
+
+  > Vault provides bridge APIs for common plugin systems on Bukkit servers.
+  
+  __Main features:__
+  - Economy API
+  - Chat API
+  - Permissions API
+  
+### Packets
+
+- [ProtocolLib](https://github.com/dmulloy2/ProtocolLib) by [@aadnk](https://github.com/aadnk)/[@dmulloy2](https://github.com/dmulloy2)
+
+  > ProtocolLib provides read and write access to the Minecraft server protocol in combination with Bukkit.
+  
+  __Main features:__
+  - Packet interception
+  - Obfuscation-free API
+
+## Other Languages
+
+Who says that you can only use Java to write plugins?
+
+- [VisualBukkit](https://github.com/OfficialDonut/VisualBukkit) by [@OfficialDonut](https://github.com/OfficialDonut)
+
+  > VisualBukkit is a visual programming language for Bukkit plugins.
+  
+- [Skript](https://github.com/SkriptLang/Skript) by [@bensku](https://github.com/bensku)
+
+  > Skript is a domain specific language for Bukkit with the aim to enable non-programmers to be able to write their own plugins.
+
+- [spiglin](https://github.com/johnnyjayjay/spiglin) by [@JohnnyJayJay](https://github.com/johnnyjayjay)
+
+  > spiglin is a collection of extensions and utilities for plugins written in the [Kotlin](https://kotlinlang.org) programming language.
+  
+- [spigot-clj-template](https://github.com/johnnyjayjay/spigot-clj-template) by [@JohnnyJayJay](https://github.com/JohnnyJayJay)
+
+  > spigot-clj-template is a [Leiningen](https://leiningen.org) template to write plugins using the [Clojure](https://clojure.org) programming language.
+
+- [minecraft-python](https://github.com/Macuyiko/minecraft-python) by [@Macuyiko](https://github.com/Macuyiko)
+
+  > minecraft-python is an interpreter system leveraging [Jython](https://www.jython.org/) to write Spigot plugins in Python.
+
+## Commands
+
+High-level alternatives and extensions for Bukkit's rusty command system. 
+They all aim to reduce the boilerplate involved in writing commands the traditional way.
+
+- [Annotation Command Framework](https://github.com/aikar/commands) by [@aikar](https://github.com/aikar/)
+- [Matt's framework](https://github.com/ipsk/MattFramework) by [@ipsk](https://github.com/ipsk)
+- [kaesk](https://github.com/DRSchlaubi/kaesk) by [@DRSchlaubi](https://github.com/DRSchlaubi)
+- [simple-commands](https://github.com/Paul2708/simple-commands) by [@Paul2708](https://github.com/Paul2708)
+
+## Libraries
+
+Libraries are projects that focus on a specific aspect of plugins.
+
+### NPCs
+
+- [NPCLib](https://github.com/MinecraftLibraries/NPCLib) by [@JitseB](https://github.com/JitseB)
+
+  > Library that allows developers to create NPCs with an easy-to-use API.
+- [CitizensAPI](https://github.com/CitizensDev/CitizensAPI) by [@fullwall](https://github.com/fullwall)
+
+  > API to create and manage NPCs using the [Citizens](https://github.com/CitizensDev/Citizens2) plugin
+
+### Maps
+
+- [spigot-maps](https://github.com/johnnyjayjay/spigot-maps) by [@JohnnyJayJay](https://github.com/johnnyjayjay)
+  
+  > Library to render custom images, gifs and text on Minecraft map items
+  
+  __Main features:__
+  - Lots of customisation (how often to render, to whom to render, ...)
+  - Tools to resize/crop/divide images and gifs to better fit maps
+  - Persistence API
+  
+### GUIs
+
+- [AnvilGUI](https://github.com/WesJD/AnvilGUI) by [@WesJD](https://github.com/WesJD/)
+
+  > AnvilGUI provides an API to open an anvil inventory that reacts on renaming.
+
+  __Main features__:
+  - support of nearly every version
+  - easy-to-use builder
+  - set title, items, closing listener and completion listener
+
+- [SmartInvs](https://github.com/MinusKube/SmartInvs) by [@MinusKube](https://github.com/MinusKube/)
+
+  > SmartInvs provides an interface for creating inventories by setting clickable items.
+
+  __Main features__:
+  - Iterator for inventory slots
+  - Page system
+  - Util methods to fill an inventory's row/column/borders/...
+  - Actions when player clicks on an item
+
+  More features and examples can be found [here](https://minuskube.gitbook.io/smartinvs/).
+
+## Scoreboards
+
+- [Netherboard](https://github.com/MinusKube/Netherboard) by [@MinusKube](https://github.com/MinusKube/)
+
+  > Netherboard provides a simple-to-use wrapper for scoreboards.
+
+  __Main features__:
+  - simple syntax for creation `BPlayerBoard board = Netherboard.instance().createBoard(player, scoreboard, "My Scoreboard");`
+  - simple syntax for adding/removing scores: `board.set("Test Score", 5);`, `board.remove(5)`
+
+- [MultiLineAPI](https://github.com/iso2013/MultiLineAPI) by [@iso2013](https://github.com/iso2013/)
+
+  > This API adds custom lines of text below a players name.
+  
+## Holograms
+
+- [HolographicDisplays](https://github.com/filoghost/HolographicDisplays) by [@filoghost](https://github.com/filoghost)
+
+  > Plugin and API to create holograms.
+  
+## Worlds
+
+- [WorldGeneratorAPI](https://github.com/rutgerkok/WorldGeneratorApi) by [@rutgerkok](https://github.com/rutgerkok)
+
+  > API to create custom world generators easily.
+  
+- [WorldEdit](https://github.com/EngineHub/WorldEdit) by [@sk89q](https://github.com/sk89q)
+  
+  > Plugin and API to manipulate Minecraft worlds.
+  
+- [FastAsyncWorldEdit](https://github.com/IntellectualSites/FastAsyncWorldEdit) by [@boy0001](https://github.com/boy0001)
+
+  > Fork of WorldEdit that operates asynchronously for higher performance.
+  
+- [WorldGuard](https://github.com/EngineHub/WorldGuard) by [@sk89q](https://github.com/sk89q)
+
+  > Plugin and API to manage and protect custom areas of Minecraft worlds.
   
 - [Slime-World-Manager](https://github.com/Grinderwolf/Slime-World-Manager) by [@Grinderwolf](https://github.com/Grinderwolf/)
 
   > Implementation of the Slime Region Format, developed by the Hypixel Dev Team.
-  
-- [MCProtocolLib](https://github.com/Steveice10/MCProtocolLib) by [@Steveice10](https://github.com/Steveice10/MCProtocolLib)
-
-  > MCProtocolLib provides a protocol library to send and receive packets without using Spigot as dependency.

--- a/api-repository.md
+++ b/api-repository.md
@@ -211,6 +211,12 @@ Libraries are projects that focus on a specific aspect of plugins.
 
   > Plugin and API to create holograms.
   
+### NBT
+
+- [Item-NBT-API](https://github.com/tr7zw/Item-NBT-API) by [@tr7zw](https://github.com/tr7zw)
+
+  > NMS-free NBT api with yaml, json, SQL and Redis serialization.
+  
 ### Worlds
 
 - [WorldGeneratorAPI](https://github.com/rutgerkok/WorldGeneratorApi) by [@rutgerkok](https://github.com/rutgerkok)

--- a/requirements.md
+++ b/requirements.md
@@ -8,7 +8,7 @@ This file lists information and questions that have to be specified and answered
 
 - Are you using Spigot, Paper or something else?
 - (Are you using BungeeCord?)
-- On which version runs the server?
+- On which version does the server run?
   - Should the plugin support a range of versions, e.g. 1.8 to 1.14.4?
 
 ## Configuration
@@ -16,10 +16,10 @@ This file lists information and questions that have to be specified and answered
 
 - Should the plugin provide a configuration?
 - What do you want to configure?
-  - Give a detailed description about the configuration fields including type (int, message, ...) and impact.
-- If you edit the configuration, when should the changes be active?
+  - Give a detailed description about the configuration fields including type (int, message, ...) and purpose.
+- If you edit the configuration, when should the changes become active?
   - after a plugin restart/reload?
-  - instant?
+  - instantly?
   - after executing a command like `/config reload`?
 
 ## Messages
@@ -34,16 +34,16 @@ Please provide screenshots and detailed descriptions for every inventory.
 You can create an inventory by filling a chest in creative.
 
 ## Commands
-> Commands are very common. So it's just more important to fully specify the commands.
+> More often than not, commands provide the most essential user interface of a plugin, so it's important to specify them up front.
 
 - What commands do you want?
 
 The following information should be given for _every_ command.
-- Give a detailed description about the command and what it should do if executed.
+- Give a detailed description about the command and what it should do when executed.
 - Who is allowed to execute it?
   - players with a special permission?
   - OP players?
-  - only console?
+  - only the console?
   - ...
 - Describe every parameter of the command.
   - optional or not?
@@ -56,17 +56,17 @@ The following information should be given for _every_ command.
 The data has to be stored somewhere.
 
 - Where should the data be stored?
-  - SQL database (MySQL, sqlLite, Postgres, ...)
-  - non-SQL database (MongoDB, ...)
-  - plain text file (`.json` file in `plugins/`, ...)
+  - SQL database (SQLite, PostgreSQL, MySQL ...)
+  - NoSQL database (MongoDB, ...)
+  - files (`.json` file in `plugins/`, ...)
   - in-memory (the data is only available if the server is running and no data is saved after restarting the server)
 - What kind of data should be stored? 
   
 
 ## Others
-- Should the plugin be "reload-save"? Meaning reloading the server should not break the plugin.
+- Should the plugin be "reload-safe"? Meaning reloading the server should not break the plugin.
 - Should the plugin provide an API that can be accessed by other plugins?
   - And if so, please specify the interface.
-  - Should the plugin call own events?
+  - Should the plugin define own events?
 - Should external APIs be used in the plugin? (e.g. Vault)
 - Are there plugins/APIs, you _don't_ want to have on the server to run the developed plugin?

--- a/servers.md
+++ b/servers.md
@@ -54,7 +54,11 @@ I case you want to play around with the protocol in Java yourself, this may be o
 
 ### Proxies
 
-*Information about BungeeCord and its descendants TBA...*
+Reverse proxies can be used to coordinate connections between different servers.
+
+- [BungeeCord](https://github.com/SpigotMC/BungeeCord)
+  - [Waterfall](https://github.com/PaperMC/Waterfall)
+    - [Travertine](https://github.com/PaperMC/Travertine)
 
 ## Bedrock Edition
 

--- a/servers.md
+++ b/servers.md
@@ -1,0 +1,74 @@
+# Minecraft Servers
+
+## Java Edition
+
+The Minecraft Java Edition client knows how to communicate with any TCP server that follows the [Minecraft server protocol](https://wiki.vg/Protocol](https://wiki.vg/Protocol). Servers that conform to this are called "Notchian" servers. While there is an [official implementation](https://www.minecraft.net/en-us/download/server) of this server provided by Mojang, there are re-implementations and modifications of it.
+
+### Modifications
+
+Below you can see a hierarchy of the most popular server software based on the official server. 
+
+- [Vanilla Server](https://www.minecraft.net/en-us/download/server)
+
+  - [CraftBukkit](https://bukkit.org)
+
+    - [Spigot](https://spigotmc.org)
+
+      - [TacoSpigot](https://tacospigot.github.io)
+
+      - [PaperMC](https://papermc.io)
+
+  - [Sponge](https://spongepowered.org)
+
+#### CraftBukkit
+
+[CraftBukkit](https://bukkit.org/) is the most commonly known modification of the vanilla server. It doesn't change or modify the protocol, but it provides an API (Bukkit) for server-side modifications called plugins. CraftBukkit and Bukkit themselves have in turn be forked and modified multiple times. The most popular CraftBukkit fork nowadays is Spigot, which also has several popular forks. 
+
+CraftBukkit and most of its descendants are compatible with each other for the most part, meaning that you can often write a plugin for one of them and it will work on all of them.
+
+See [the API repository](./api-repository.md) for a list of tools for Bukkit-based plugin development.
+
+#### Sponge
+
+[Sponge](https://spongepowered.org) is another modified vanilla server independent from CraftBukkit. It also has a plugin system with an API to create server-side mods, but additionally, it's commonly used as a server for the [Forge](http://files.minecraftforge.net) modding platform.
+
+### Re-Implementations
+
+There is a number of reasons why it may be beneficial to use a server that does not depend on the official vanilla server at all. First of all, it prevents the [licensing issues that occur when redistributing proprietary code](https://blog.jwf.io/2020/04/open-source-minecraft-bukkit-gpl/). Second of all, it gives you a lot more freedom in how to structure the server, which systems to use etc.
+
+There are many independent Notchian server implementations and you can find [unofficial lists](https://wiki.vg/Server_List) on the internet. Below, we list a couple of Java-based servers that we find interesting.
+
+- [Cleanstone](https://github.com/CleanstoneMC/Cleanstone) by [@Fionera](https://github.com/Fionera) and [@MyzelYam](https://github.com/MyzelYam)
+
+  > Cleanstone is an alternative server software that is based on Spring and Multi-Threading.
+- [Minestom](https://github.com/Minestom/Minestom) by [@Minestom](https://github.com/Minestom/)
+
+  > Minestom is an alternative server software that aims to improve the performance.
+
+   __Main features__:
+  - Remove the overhead of vanilla features
+  - Multi-threaded (Chunks & Entities)
+  - Instance system which is much more scalable than worlds
+  - Modern API
+
+I case you want to play around with the protocol in Java yourself, this may be of use:
+
+- [MCProtocolLib](https://github.com/Steveice10/MCProtocolLib) by [@Steveice10](https://github.com/Steveice10/MCProtocolLib)
+
+  > MCProtocolLib provides a protocol library to send and receive packets without using Spigot as dependency.
+
+### Proxies
+
+*Information about BungeeCord and its descendants TBA...*
+
+## Bedrock Edition
+
+...
+
+## Bridges
+
+There are attempts to construct bridges between the Bedrock and the Java edition protocols, so that players from both editions can play together. Note that none is fully production ready or 100% functional yet.
+
+- [Geyser](https://github.com/GeyserMC/Geyser/) by [@GeyserMC](https://github.com/GeyserMC/), a proxy allowing Bedrock players to join Java servers
+
+- [Waterdog](https://github.com/yesdog/Waterdog) by [@yesdog](https://github.com/yesdog), a fork of Waterfall/BungeeCord adding Bedrock protocol support

--- a/servers.md
+++ b/servers.md
@@ -2,22 +2,17 @@
 
 ## Java Edition
 
-The Minecraft Java Edition client knows how to communicate with any TCP server that follows the [Minecraft server protocol](https://wiki.vg/Protocol](https://wiki.vg/Protocol). Servers that conform to this are called "Notchian" servers. While there is an [official implementation](https://www.minecraft.net/en-us/download/server) of this server provided by Mojang, there are re-implementations and modifications of it.
+The Minecraft Java Edition client knows how to communicate with any TCP server that follows the [Minecraft server protocol](https://wiki.vg/Protocol). Servers that conform to this are called "Notchian" servers. While there is an [official implementation](https://www.minecraft.net/en-us/download/server) of this server provided by Mojang, there are re-implementations and modifications of it.
 
 ### Modifications
 
 Below you can see a hierarchy of the most popular server software based on the official server. 
 
 - [Vanilla Server](https://www.minecraft.net/en-us/download/server)
-
   - [CraftBukkit](https://bukkit.org)
-
     - [Spigot](https://spigotmc.org)
-
       - [TacoSpigot](https://tacospigot.github.io)
-
       - [PaperMC](https://papermc.io)
-
   - [Sponge](https://spongepowered.org)
 
 #### CraftBukkit


### PR DESCRIPTION
This PR restructures the API repository file, adding a table of contents, grouping elements in a reasonable manner and adding a couple of APIs/tools/libraries overall.

It also adds a new file called `servers.md` that is supposed to provide information about Minecraft servers, and, more specifically, about software to run and develop them. There is still a lot of room for improvement in terms of explanations and software being listed, but that may be subject to a future pull request :) 

Oh, and I also went over the `requirements.md` and adjusted the wording here and there, hopefully for the better.